### PR TITLE
Fix docker-compose.yml validation error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,16 +13,8 @@ services:
     volumes:
       - ./logs:/var/log/nginx
     networks:
-      - lawyer-network  # ← Измените на lawyer-network
-    depends_on:
-      - api  # ← Добавьте зависимость
-
-  # Раскомментируйте API секцию или используйте external network
-  api:
-    external_name: legal-system-api
-    networks:
       - lawyer-network
 
 networks:
   lawyer-network:
-    external: true  # ← Используем существующую сеть от API
+    external: true


### PR DESCRIPTION
- Remove invalid external_name property from api service
- Keep only frontend service that connects to existing lawyer-network
- API container legal-system-api should already exist in the network

This fixes the docker-compose validation error and allows proper deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)